### PR TITLE
Add chapter 3 examples

### DIFF
--- a/3_05.js
+++ b/3_05.js
@@ -1,0 +1,44 @@
+// ...
+  // ...
+    // ...
+class Gear {
+  constructor(chainring, cog, rim, tire) {
+    this._chainring = chainring;
+    this._cog = cog;
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  gear_inches() {
+    return this.ratio() * new Wheel(this.rim, this.tire).diameter();
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+// ...
+}
+
+class Wheel {
+  constructor(rim, tire) {
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  diameter() {
+    return this.rim + (this.tire * 2);
+  }
+// ...
+}
+
+console.log(new Gear(52, 11, 26, 1.5).gear_inches());
+// => 137.0909090909091
+

--- a/3_10.js
+++ b/3_10.js
@@ -1,0 +1,38 @@
+class Gear {
+  constructor(chainring, cog, wheel) {
+    this._chainring = chainring;
+    this._cog = cog;
+    this._wheel = wheel;
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get wheel() { return this._wheel; }
+
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+class Wheel {
+  constructor(rim, tire) {
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  diameter() {
+    return this.rim + (this.tire * 2);
+  }
+}
+
+// Gear expects a 'Duck' that knows 'diameter'
+console.log(new Gear(52, 11, new Wheel(26, 1.5)).gear_inches());
+// => 137.0909090909091
+

--- a/3_15.js
+++ b/3_15.js
@@ -1,0 +1,37 @@
+class Gear {
+  constructor(chainring, cog, rim, tire) {
+    this._chainring = chainring;
+    this._cog = cog;
+    this._wheel = new Wheel(rim, tire);
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get wheel() { return this._wheel; }
+
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+class Wheel {
+  constructor(rim, tire) {
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  diameter() {
+    return this.rim + (this.tire * 2);
+  }
+}
+
+console.log(new Gear(52, 11, 26, 1.5).gear_inches());
+// => 137.0909090909091
+

--- a/3_20.js
+++ b/3_20.js
@@ -1,0 +1,43 @@
+class Gear {
+  constructor(chainring, cog, rim, tire) {
+    this._chainring = chainring;
+    this._cog = cog;
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+
+  get wheel() {
+    return new Wheel(this.rim, this.tire);
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+class Wheel {
+  constructor(rim, tire) {
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  diameter() {
+    return this.rim + (this.tire * 2);
+  }
+}
+
+console.log(new Gear(52, 11, 26, 1.5).gear_inches());
+// => 137.0909090909091
+

--- a/3_25.js
+++ b/3_25.js
@@ -1,0 +1,31 @@
+/*
+ * ADAPTATION: Including actual classes here to clarify that the examples show
+ * methods -- they reference instances variables.
+ */
+
+class Gear {
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+}
+
+class ComplexGear {
+  gear_inches() {
+    // ... a few lines of scary math
+    let foo = some_intermediate_result * this.wheel.diameter();
+    // ... more lines of scary math
+  }
+}
+
+class ComplexGearWithEncapsulatedDiameter {
+  gear_inches() {
+    // ... a few lines of scary math
+    let foo = some_intermediate_result * this.diameter();
+    // ... more lines of scary math
+  }
+
+  diameter() {
+    return this.wheel.diameter();
+  }
+}
+

--- a/3_30.js
+++ b/3_30.js
@@ -1,0 +1,129 @@
+class Wheel {
+  constructor(rim, tire) {
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  diameter() {
+    return this.rim + (this.tire * 2);
+  }
+}
+
+/**
+ * Using fixed args
+ */
+
+class GearUsingFixedArgs {
+  constructor(chainring, cog, wheel) {
+    this._chainring = chainring;
+    this._cog = cog;
+    this._wheel = wheel;
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get wheel() { return this._wheel; }
+
+  // ...
+
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+console.log(new GearUsingFixedArgs(
+  52,
+  11,
+  new Wheel(26, 1.5)
+).gear_inches());
+// => 137.0909090909091
+
+/*
+ * Using "hash"
+ *
+ * NOTE: In JavaScript, this might more commonly be referred to as using an
+ * object parameter. The idea is to make the caller explicitly name the
+ * parameters when they call the method.
+ */
+
+class GearUsingHash {
+  constructor(args) {
+    this._chainring = args['chainring']; // NOTE: could instead be `args.chainring`
+    this._cog       = args['cog'];
+    this._wheel     = args['wheel'];
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get wheel() { return this._wheel; }
+
+  // ...
+
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+console.log(new GearUsingHash({
+  chainring: 52,
+  cog: 11,
+  wheel: new Wheel(26, 1.5)
+}).gear_inches());
+// => 137.0909090909091
+
+/*
+ * Using "keyword args"
+ *
+ * NOTE: Here, we're using destructuring on the constructor's parameters to
+ * achieve something similar to the Ruby keyword argument example.
+ *
+ * SEE: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
+ */
+
+class GearUsingKeywordArgs {
+  constructor({ chainring, cog, wheel }) {
+    this._chainring = chainring
+    this._cog = cog;
+    this._wheel = wheel;
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get wheel() { return this._wheel; }
+
+  // ...
+
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+console.log(new GearUsingKeywordArgs({
+  cog: 11,
+  chainring: 52,
+  wheel: new Wheel(26, 1.5)
+}).gear_inches());
+// => 137.0909090909091
+
+console.log(new GearUsingKeywordArgs({
+  wheel: new Wheel(26, 1.5),
+  chainring: 52,
+  cog: 11
+}).gear_inches());
+// => 137.0909090909091
+

--- a/3_35.js
+++ b/3_35.js
@@ -1,0 +1,96 @@
+class Wheel {
+  constructor(rim, tire) {
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  diameter() {
+    return this.rim + (this.tire * 2);
+  }
+}
+
+/*
+ * KEYWORD ARGS
+ *     keyword arg with simple defaults
+ *
+ * NOTE: Here, we're combining destructuring with function defaults to
+ * accomplish something similar to keyword args with default values.
+ *
+ * SEE: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment
+ * SEE: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters
+ */
+class Gear {
+  constructor({ chainring = 40, cog = 18, wheel }) {
+    this._chainring = chainring;
+    this._cog = cog;
+    this._wheel = wheel;
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get wheel() { return this._wheel; }
+  // ...
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+console.log(new Gear({
+  wheel: new Wheel(26, 1.5)
+}).chainring);
+// => 40;
+
+/*
+ * KEYWORD ARGS
+ *     keyword arg with defaults
+ *
+ * NOTE: Sandi's point here is that the `constructor` executes in the new
+ * instance of Gear, so it should be able to send messages to itself.
+ */
+
+class GearWithDefaultMethod {
+  constructor({ 
+    chainring = this.default_chainring(),
+    cog = 18,
+    wheel
+  }) {
+    this._chainring = chainring;
+    this._cog = cog;
+    this._wheel = wheel;
+  }
+
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+  get wheel() { return this._wheel; }
+
+  default_chainring() {
+    return (100 / 2) - 10;
+  }
+  // ...
+  gear_inches() {
+    return this.ratio() * this.wheel.diameter();
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+console.log(new GearWithDefaultMethod({
+  wheel: new Wheel(26, 1.5)
+}).chainring);
+// => 40
+
+console.log(new GearWithDefaultMethod({
+  chainring: 52,
+  wheel: new Wheel(26, 1.5)
+}).chainring);
+// => 52
+

--- a/3_40.js
+++ b/3_40.js
@@ -1,0 +1,69 @@
+/*
+ * ADAPTATION: Without the equivalent of Ruby's "module" keyword, we'll just
+ * define the Gear class here inside an object acting as a namespace.
+ *
+ * It looks a bit odd here, but you'll often see packages where the main file
+ * exports an object with properties that are other objects/classes it intends
+ * to make available. For example:
+ *
+ * ```
+ * const Gear = require('./Gear');
+ *
+ * module.exports = {
+ *   Gear,
+ * };
+ * ```
+ */
+
+// When Gear is part of some external interface
+const SomeFramework = {
+  Gear: class Gear {
+    constructor(chainring, cog, wheel) {
+      this._chainring = chainring;
+      this._cog = cog;
+      this._wheel = wheel;
+    }
+
+    get chainring() { return this._chainring; }
+    get cog() { return this._cog; }
+    get wheel() { return this._wheel; }
+    // ...
+    gear_inches() {
+      return this.ratio() * this.wheel.diameter();
+    }
+
+    ratio() {
+      return this.chainring / this.cog;
+    }
+  }
+};
+
+class Wheel {
+  constructor(rim, tire) {
+    this._rim = rim;
+    this._tire = tire;
+  }
+
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+
+  diameter() {
+    return this.rim + (this.tire * 2);
+  }
+}
+
+// Wrap the interface to protect yourself from changes
+class GearWrapper {
+  static gear({ chainring, cog, wheel }) {
+    return new SomeFramework.Gear(chainring, cog, wheel);
+  }
+}
+
+// Now you can create a new Gear using keyword arguments
+console.log(GearWrapper.gear({
+  chainring: 52,
+  cog: 11,
+  wheel: new Wheel(26, 1.5)
+}).gear_inches());
+// => 137.0909090909091
+

--- a/3_45.js
+++ b/3_45.js
@@ -1,0 +1,48 @@
+// with keyword args
+class Gear {
+  constructor({ chainring, cog }) {
+    this._chainring = chainring;
+    this._cog = cog;
+  }
+  
+  get chainring() { return this._chainring; }
+  get cog() { return this._cog; }
+
+  gear_inches(diameter) {
+    return this.ratio() * diameter;
+  }
+
+  ratio() {
+    return this.chainring / this.cog;
+  }
+}
+
+class Wheel {
+  constructor({ rim, tire, chainring, cog }) {
+    this._rim = rim;
+    this._tire = tire;
+    this._gear = new Gear({ chainring, cog });
+  }
+
+  get rim() { return this._rim; }
+  get tire() { return this._tire; }
+  get gear() { return this._gear; }
+
+  diameter() {
+    return this.rim + (this.tire * 2);
+  }
+
+  gear_inches() {
+    return this.gear.gear_inches(this.diameter());
+  }
+  //
+}
+
+console.log(new Wheel({
+  rim: 26,
+  tire: 1.5,
+  chainring: 52,
+  cog: 11
+}).gear_inches());
+// 137.0909090909091
+


### PR DESCRIPTION
Adds example files that mirror and translate the executable examples for chapter 3 in the official [`poodr2` repository](https://github.com/skmetz/poodr2).

Interesting takeaways:
- The `constructor`'s parameters can call methods on the instance (see the example for encapsulating complex defaults)

Examples of adaptations made where Ruby !== JavaScript:
- "hash" => object literal
- "keyword args" => destructured object literal as parameter