### PR TITLE
Add chapter 5 examples

### DIFF
--- a/5_05.js
+++ b/5_05.js
@@ -1,0 +1,38 @@
+class Trip {
+  constructor(bicycles, customers, vehicle) {
+    this._bicycles = bicycles;
+    this._customers = customers;
+    this._vehicle = vehicle;
+  }
+
+  get bicycles() { return this._bicycles; }
+  get customers() { return this._customers; }
+  get vehicle() { return this._vehicle; }
+
+  // this 'mechanic' argument could be of any class
+  prepare(mechanic) {
+    mechanic.prepare_bicycles(this.bicycles);
+  }
+}
+
+// if you happen to pass an instance of *this* class, it works
+class Mechanic {
+  prepare_bicycles(bicycles) {
+    bicycles.forEach((bicycle) => this.prepare_bicycle(bicycle));
+  }
+
+  prepare_bicycle(bicycle) {
+    // ...
+  }
+}
+
+class Bicycle {}
+class Customer {}
+class Vehicle {}
+
+new Trip(
+  [new Bicycle(), new Bicycle(), new Bicycle()],
+  [new Customer(), new Customer()],
+  new Vehicle()
+).prepare(new Mechanic());
+

--- a/5_10.js
+++ b/5_10.js
@@ -1,0 +1,79 @@
+// Trip preparation becomes more complicated
+class Trip {
+  constructor(bicycles, customers, vehicle) {
+    this._bicycles = bicycles;
+    this._customers = customers;
+    this._vehicle = vehicle;
+  }
+
+  get bicycles() { return this._bicycles; }
+  get customers() { return this._customers; }
+  get vehicle() { return this._vehicle; }
+
+  prepare(preparers) {
+    preparers.forEach((preparer) => {
+      switch (preparer.constructor) {
+        case Mechanic:
+          preparer.prepare_bicycles(this.bicycles);
+          break;
+        case TripCoordinator:
+          preparer.buy_food(this.customers);
+          break;
+        case Driver:
+          preparer.gas_up(this.vehicle);
+          preparer.fill_water_tank(this.vehicle);
+          break;
+      }
+    });
+  }
+}
+
+// when you introduce TripCoordinator and Driver
+class TripCoordinator {
+  buy_food(customers) {
+    // ...
+    console.log('TripCoordinator buy_food');
+  }
+}
+
+class Driver {
+  gas_up(vehicle) {
+    // ...
+    console.log('Driver gas_up');
+  }
+
+  fill_water_tank(vehicle) {
+    // ...
+    console.log('Driver fill_water_tank');
+  }
+}
+
+class Mechanic {
+  prepare_bicycles(bicycles) {
+    bicycles.forEach((bicycle) => this.prepare_bicycle(bicycle));
+  }
+
+  prepare_bicycle(bicycle) {
+    // ...
+    console.log(`Mechanic prepare_bicycle ${bicycle}`);
+  }
+}
+
+class Bicycle {}
+class Customer {}
+class Vehicle {}
+
+const trip = new Trip(
+  [new Bicycle(), new Bicycle(), new Bicycle()],
+  [new Customer(), new Customer()],
+  new Vehicle(),
+);
+
+const preparers = [
+  new TripCoordinator(),
+  new Driver(),
+  new Mechanic(),
+];
+
+trip.prepare(preparers);
+

--- a/5_15.js
+++ b/5_15.js
@@ -1,0 +1,84 @@
+// Trip preparation becomes easier
+class Trip {
+  constructor(bicycles, customers, vehicle) {
+    this._bicycles = bicycles;
+    this._customers = customers;
+    this._vehicle = vehicle;
+  }
+
+  get bicycles() { return this._bicycles; }
+  get customers() { return this._customers; }
+  get vehicle() { return this._vehicle; }
+
+  prepare(preparers) {
+    preparers.forEach((preparer) => {
+      preparer.prepare_trip(this);
+    });
+  }
+  // ...
+}
+
+// when every preparer is a Duck that responds to 'prepare_trip'
+class Mechanic {
+  prepare_trip(trip) {
+    trip.bicycles.forEach((bicycle) => this.prepare_bicycle(bicycle));
+  }
+
+  // ...
+  prepare_bicycles(bicycles) {
+    bicycles.forEach((bicycle) => this.prepare_bicycle(bicycle));
+  }
+
+  prepare_bicycle(bicycle) {
+    // ...
+    console.log(`Mechanic prepare_bicycle ${bicycle}`);
+  }
+}
+
+class TripCoordinator {
+  prepare_trip(trip) {
+    this.buy_food(trip.customers);
+  }
+
+  buy_food(customers) {
+    // ...
+    console.log('TripCoordinator buy_food');
+  }
+}
+
+class Driver {
+  prepare_trip(trip) {
+    const vehicle = trip.vehicle;
+    this.gas_up(vehicle);
+    this.fill_water_tank(vehicle);
+  }
+
+  // ...
+  gas_up(vehicle) {
+    // ...
+    console.log('Driver gas_up');
+  }
+
+  fill_water_tank(vehicle) {
+    // ...
+    console.log('Driver fill_water_tank');
+  }
+}
+
+class Bicycle {}
+class Customer {}
+class Vehicle {}
+
+const trip = new Trip(
+  [new Bicycle(), new Bicycle(), new Bicycle()],
+  [new Customer(), new Customer()],
+  new Vehicle(),
+);
+
+const preparers = [
+  new TripCoordinator(),
+  new Driver(),
+  new Mechanic(),
+];
+
+trip.prepare(preparers);

--- a/5_20.js
+++ b/5_20.js
@@ -1,0 +1,198 @@
+class Mechanic {
+  // prepare_trip(trip) {
+  //   trip.bicycles.forEach((bicycle) => this.prepare_bicycle(bicycle));
+  // }
+  // ...
+
+  prepare_bicycles(bicycles) {
+    bicycles.forEach((bicycle) => this.prepare_bicycle(bicycle));
+  }
+
+  prepare_bicycle(bicycle) {
+    // ...
+    console.log(`Mechanic prepare_bicycle ${bicycle}`);
+  }
+}
+
+class TripCoordinator {
+  // prepare_trip(trip) {
+  //   this.buy_food(trip.customers);
+  // }
+  // ...
+
+  buy_food(customers) {
+    // ...
+    console.log('TripCoordinator buy_food');
+  }
+}
+
+class Driver {
+  // prepare_trip(trip) {
+  //   const vehicle = trip.vehicle;
+  //   this.gas_up(vehicle);
+  //   this.fill_water_tank(vehicle);
+  // }
+  // ...
+
+  gas_up(vehicle) {
+    // ...
+    console.log('Driver gas_up');
+  }
+
+  fill_water_tank(vehicle) {
+    // ...
+    console.log('Driver fill_water_tank');
+  }
+}
+
+class Bicycle {}
+class Customer {}
+class Vehicle {}
+
+/*************************
+ * Initial example
+ *************************/
+class Trip {
+  constructor(bicycles, customers, vehicle) {
+    this._bicycles = bicycles;
+    this._customers = customers;
+    this._vehicle = vehicle;
+  }
+
+  get bicycles() { return this._bicycles; }
+  get customers() { return this._customers; }
+  get vehicle() { return this._vehicle; }
+
+  prepare(preparers) {
+    preparers.forEach((preparer) => {
+      switch (preparer.constructor) {
+        case Mechanic:
+          preparer.prepare_bicycles(this.bicycles);
+          break;
+        case TripCoordinator:
+          preparer.buy_food(this.customers);
+          break;
+        case Driver:
+          preparer.gas_up(this.vehicle);
+          preparer.fill_water_tank(this.vehicle);
+          break;
+      }
+    });
+  }
+}
+
+console.log('\nInitial example:');
+let trip = new Trip(
+  [new Bicycle(), new Bicycle(), new Bicycle()],
+  [new Customer(), new Customer()],
+  new Vehicle(),
+);
+
+let preparers = [
+  new TripCoordinator(),
+  new Driver(),
+  new Mechanic(),
+];
+
+trip.prepare(preparers);
+
+/*************************
+ * instanceof example
+ * ADAPTATION: instanceof used in place of Ruby's "kind_of?"
+ *************************/
+class TripUsingInstanceOf {
+  constructor(bicycles, customers, vehicle) {
+    this._bicycles = bicycles;
+    this._customers = customers;
+    this._vehicle = vehicle;
+  }
+
+  get bicycles() { return this._bicycles; }
+  get customers() { return this._customers; }
+  get vehicle() { return this._vehicle; }
+
+  prepare(preparers) {
+    preparers.forEach((preparer) => {
+      if (preparer instanceof Mechanic) {
+        preparer.prepare_bicycles(this.bicycles);
+      } else if (preparer instanceof TripCoordinator) {
+        preparer.buy_food(this.customers);
+      } else if (preparer instanceof Driver) {
+        preparer.gas_up(this.vehicle);
+        preparer.fill_water_tank(this.vehicle);
+      }
+    });
+  }
+}
+
+console.log('\ninstanceof example:');
+// NOTE: defined above, reassigned here...
+trip = new TripUsingInstanceOf(
+  [new Bicycle(), new Bicycle(), new Bicycle()],
+  [new Customer(), new Customer()],
+  new Vehicle(),
+);
+
+preparers = [
+  new TripCoordinator(),
+  new Driver(),
+  new Mechanic(),
+];
+
+trip.prepare(preparers);
+
+/*************************
+ * 'in' operator example
+ *
+ * ADAPTATION: There are multiple ways to check if an object responds to a
+ * particular message. Commonly, you'll see code checking to see that a property
+ * is defined on an object by calling it in an if condition, or using Object's
+ * 'hasOwnProperty' method. 
+ * This example uses the 'in' operator, because it checks for the existence of
+ * the property anywhere in the object's prototype chain -- which seems most
+ * similar to the example using Ruby's 'responds_to?' ... just be aware this
+ * isn't a great translation.
+ *
+ * SEE: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in
+ * SEE: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty#Description
+ *************************/
+
+class TripUsingInOperator {
+  constructor(bicycles, customers, vehicle) {
+    this._bicycles = bicycles;
+    this._customers = customers;
+    this._vehicle = vehicle;
+  }
+
+  get bicycles() { return this._bicycles; }
+  get customers() { return this._customers; }
+  get vehicle() { return this._vehicle; }
+
+  prepare(preparers) {
+    preparers.forEach((preparer) => {
+      if ('prepare_bicycles' in preparer) {
+        preparer.prepare_bicycles(this.bicycles);
+      } else if ('buy_food' in preparer) {
+        preparer.buy_food(this.customers);
+      } else if ('gas_up' in preparer) {
+        preparer.gas_up(this.vehicle);
+        preparer.fill_water_tank(this.vehicle);
+      }
+    });
+  }
+}
+
+console.log('\nin operator example:');
+trip = new TripUsingInOperator(
+  [new Bicycle(), new Bicycle(), new Bicycle()],
+  [new Customer(), new Customer()],
+  new Vehicle(),
+);
+
+preparers = [
+  new TripCoordinator(),
+  new Driver(),
+  new Mechanic(),
+];
+
+trip.prepare(preparers);

--- a/5_25.js
+++ b/5_25.js
@@ -1,0 +1,17 @@
+/*
+ * NOTE: This example is a bit dense to translate because it is exploring code
+ * taken directly from a piece of Ruby on Rails. I've chosen not to try
+ * recreating it here.
+ *
+ * The example aims to show that sometimes checking for an object's
+ * class/type or the messages it responds to can be a useful technique, and that
+ * it does not necessitate replacement with a duck type.
+ *
+ * The code specifically demonstrates checking for stable, core language
+ * classes, where using a duck type would require changing these classes:
+ * possible, but risky.
+ *
+ * Best to just go look at the actual Ruby example -- preferably with the full 
+ * context of the book.
+ */
+


### PR DESCRIPTION
Adds example files that mirror and translate the executable examples for chapter 5 in the official [`poodr2` repository](https://github.com/skmetz/poodr2).

I completely avoided trying to recreate example "5_25.rb" that is pulled directly from Rails. It might be worth revisiting in the future, but for now, I'd recommend just getting as much context as possible from the book to understand it. 

Interesting takeaways:
- Code that checks for the type of an object to decide what message to send is usually asking to be replaced with a duck type.
- The duck type trade off is more abstraction for less unstable dependencies.

Examples of adaptations made where Ruby !== JavaScript:
- "kind_of?" => "instanceof" (roughly)
- "responds_to?" => the "in" operator (roughly)